### PR TITLE
feat: generateOpenApiSpec

### DIFF
--- a/fixtures/openapiTest.ts
+++ b/fixtures/openapiTest.ts
@@ -1,0 +1,89 @@
+import { Tspec } from '../src/types/tspec';
+
+export const mockSpec: Tspec.ParsedApiSpec = {
+  operationId: 'GetSeries',
+  url: 'GET /manta/v1/series/{id}',
+  summary: 'Retrieve a series',
+  description: 'Retrieve a series',
+  tags: ['Series', 'Front'],
+  auth: 'JWT',
+  path: {
+    "deprecated": false,
+    "name": "path",
+    "required": true,
+    "type": {
+      "typeName": "nestedObjectLiteral",
+      "properties": [
+        {
+          "example": 1255,
+          "description": "Series id",
+          "deprecated": false,
+          "name": "id",
+          "required": true,
+          "type": {
+            "typeName": "number"
+          }
+        }
+      ]
+    }
+  },
+  query: {
+    "deprecated": false,
+    "name": "query",
+    "required": true,
+    "type": {
+      "typeName": "nestedObjectLiteral",
+      "properties": [
+        {
+          "deprecated": false,
+          "name": "debug",
+          "required": false,
+          "type": {
+            "typeName": "boolean"
+          }
+        }
+      ]
+    }
+  },
+  response: {
+    "deprecated": false,
+    "name": "response",
+    "required": true,
+    "type": {
+      "typeName": "nestedObjectLiteral",
+      "properties": [
+        {
+          "deprecated": false,
+          "name": "id",
+          "required": true,
+          "type": {
+            "typeName": "number"
+          }
+        },
+        {
+          "deprecated": false,
+          "name": "thumbnail",
+          "required": true,
+          "type": {
+            "typeName": "refAlias",
+            "refName": "Thumbnail",
+            "type": {
+              "typeName": "nestedObjectLiteral",
+              "properties": [
+                {
+                  "deprecated": false,
+                  "name": "xlarge",
+                  "required": true,
+                  "type": {
+                    "typeName": "string"
+                  }
+                }
+              ]
+            },
+            "deprecated": false
+          }
+        }
+      ]
+    }
+  }
+};

--- a/fixtures/test.ts
+++ b/fixtures/test.ts
@@ -22,6 +22,9 @@ export type GetSeriesSpec = DefineApiSpec<{
      */
     id: number;
   };
+  query: {
+    debug?: boolean;
+  };
   auth: "JWT";
   response: Series;
 }>;

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,15 @@
 import ts from "typescript";
+import fs from 'fs';
+
+import { mockSpec } from "./fixtures/openapiTest";
 import { extract } from "./src/extractor";
+import { generateOpenApiSpec } from "./src/openapi";
 
 const FILE_NAME = "./fixtures/test.ts";
 
 const program = ts.createProgram([FILE_NAME], {});
 
 extract(program);
+
+const openApiSpec = generateOpenApiSpec([mockSpec]);
+fs.writeFileSync("openapi.json", JSON.stringify(openApiSpec, undefined, 2));

--- a/index.ts
+++ b/index.ts
@@ -11,5 +11,14 @@ const program = ts.createProgram([FILE_NAME], {});
 
 extract(program);
 
-const openApiSpec = generateOpenApiSpec([mockSpec]);
+const openApiSpec = generateOpenApiSpec([mockSpec], {
+  components: {
+    securitySchemes: {
+      JWT: {
+        type: "http",
+        scheme: "bearer",
+      },
+    },
+  },
+});
 fs.writeFileSync("openapi.json", JSON.stringify(openApiSpec, undefined, 2));

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,90 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Series"
+    },
+    {
+      "name": "Front"
+    }
+  ],
+  "paths": {
+    "/manta/v1/series/{id}": {
+      "get": {
+        "tags": [
+          "Series",
+          "Front"
+        ],
+        "summary": "Retrieve a series",
+        "description": "Retrieve a series",
+        "operationId": "GetSeries",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Series id",
+            "required": true,
+            "schema": {
+              "type": "number"
+            },
+            "example": 1255
+          },
+          {
+            "name": "debug",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "thumbnail": {
+                      "properties": {
+                        "xlarge": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "xlarge"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "thumbnail"
+                  ],
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWT": []
+          }
+        ]
+      }
+    }
+  }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -86,5 +86,13 @@
         ]
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "JWT": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
   }
 }

--- a/output.json
+++ b/output.json
@@ -1,144 +1,165 @@
 {
-    "typeName": "refAlias",
-    "refName": "DefineApiSpec_GetSeriesSpecRaw_",
-    "type": {
-        "typeName": "refAlias",
-        "refName": "GetSeriesSpecRaw",
+  "typeName": "refAlias",
+  "refName": "DefineApiSpec__url%3A%60GET%2Fmanta%2Fv1%2Fseries%2F_id_%60--summary-Retrieveaseries--description-GetSeriesSpecDescription--tags%3A%5BSeries.Front%5D--path%3A_%2F***Seriesid*%40example1255*%2Fid-number--_--query%3A_debug%3F%3Aboolean--_--auth-JWT--response-Series--__",
+  "type": {
+    "typeName": "nestedObjectLiteral",
+    "properties": [
+      {
+        "deprecated": false,
+        "name": "url",
+        "required": true,
         "type": {
+          "typeName": "enum",
+          "enums": [
+            "GET /manta/v1/series/{id}"
+          ]
+        }
+      },
+      {
+        "deprecated": false,
+        "name": "summary",
+        "required": true,
+        "type": {
+          "typeName": "enum",
+          "enums": [
+            "Retrieve a series"
+          ]
+        }
+      },
+      {
+        "deprecated": false,
+        "name": "description",
+        "required": true,
+        "type": {
+          "typeName": "refAlias",
+          "refName": "GetSeriesSpecDescription",
+          "type": {
+            "typeName": "enum",
+            "enums": [
+              "Retrieve a series"
+            ]
+          },
+          "deprecated": false
+        }
+      },
+      {
+        "deprecated": false,
+        "name": "tags",
+        "required": true,
+        "type": {
+          "typeName": "tuple",
+          "types": [
+            {
+              "typeName": "enum",
+              "enums": [
+                "Series"
+              ]
+            },
+            {
+              "typeName": "enum",
+              "enums": [
+                "Front"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "deprecated": false,
+        "name": "path",
+        "required": true,
+        "type": {
+          "typeName": "nestedObjectLiteral",
+          "properties": [
+            {
+              "example": 1255,
+              "description": "Series id",
+              "deprecated": false,
+              "name": "id",
+              "required": true,
+              "type": {
+                "typeName": "number"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "deprecated": false,
+        "name": "query",
+        "required": true,
+        "type": {
+          "typeName": "nestedObjectLiteral",
+          "properties": [
+            {
+              "deprecated": false,
+              "name": "debug",
+              "required": false,
+              "type": {
+                "typeName": "boolean"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "deprecated": false,
+        "name": "auth",
+        "required": true,
+        "type": {
+          "typeName": "enum",
+          "enums": [
+            "JWT"
+          ]
+        }
+      },
+      {
+        "deprecated": false,
+        "name": "response",
+        "required": true,
+        "type": {
+          "typeName": "refAlias",
+          "refName": "Series",
+          "type": {
             "typeName": "nestedObjectLiteral",
             "properties": [
-                {
-                    "deprecated": false,
-                    "name": "url",
-                    "required": true,
-                    "type": {
-                        "typeName": "enum",
-                        "enums": [
-                            "GET /manta/v1/series/{id}"
-                        ]
-                    }
-                },
-                {
-                    "deprecated": false,
-                    "name": "summary",
-                    "required": true,
-                    "type": {
-                        "typeName": "enum",
-                        "enums": [
-                            "Retrieve a series"
-                        ]
-                    }
-                },
-                {
-                    "deprecated": false,
-                    "name": "description",
-                    "required": true,
-                    "type": {
-                        "typeName": "refAlias",
-                        "refName": "GetSeriesSpecDescription",
-                        "type": {
-                            "typeName": "enum",
-                            "enums": [
-                                "Retrieve a series"
-                            ]
-                        },
-                        "deprecated": false
-                    }
-                },
-                {
-                    "deprecated": false,
-                    "name": "tags",
-                    "required": true,
-                    "type": {
-                        "typeName": "tuple",
-                        "types": [
-                            {
-                                "typeName": "enum",
-                                "enums": [
-                                    "Series"
-                                ]
-                            },
-                            {
-                                "typeName": "enum",
-                                "enums": [
-                                    "Front"
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "deprecated": false,
-                    "name": "path",
-                    "required": true,
-                    "type": {
-                        "typeName": "nestedObjectLiteral",
-                        "properties": [
-                            {
-                                "example": 1255,
-                                "description": "Series id",
-                                "deprecated": false,
-                                "name": "id",
-                                "required": true,
-                                "type": {
-                                    "typeName": "number"
-                                }
-                            }
-                        ]
-                    }
-                },
-                {
-                    "deprecated": false,
-                    "name": "auth",
-                    "required": true,
-                    "type": {
-                        "typeName": "enum",
-                        "enums": [
-                            "JWT"
-                        ]
-                    }
-                },
-                {
-                    "deprecated": false,
-                    "name": "response",
-                    "required": true,
-                    "type": {
-                        "typeName": "refAlias",
-                        "refName": "Series",
-                        "type": {
-                            "typeName": "nestedObjectLiteral",
-                            "properties": [
-                                {
-                                    "deprecated": false,
-                                    "name": "thumbnail",
-                                    "required": true,
-                                    "type": {
-                                        "typeName": "refAlias",
-                                        "refName": "Thumbnail",
-                                        "type": {
-                                            "typeName": "nestedObjectLiteral",
-                                            "properties": [
-                                                {
-                                                    "deprecated": false,
-                                                    "name": "xlarge",
-                                                    "required": true,
-                                                    "type": {
-                                                        "typeName": "string"
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "deprecated": false
-                                    }
-                                }
-                            ]
-                        },
-                        "deprecated": false
-                    }
+              {
+                "deprecated": false,
+                "name": "id",
+                "required": true,
+                "type": {
+                  "typeName": "number"
                 }
+              },
+              {
+                "deprecated": false,
+                "name": "thumbnail",
+                "required": true,
+                "type": {
+                  "typeName": "refAlias",
+                  "refName": "Thumbnail",
+                  "type": {
+                    "typeName": "nestedObjectLiteral",
+                    "properties": [
+                      {
+                        "deprecated": false,
+                        "name": "xlarge",
+                        "required": true,
+                        "type": {
+                          "typeName": "string"
+                        }
+                      }
+                    ]
+                  },
+                  "deprecated": false
+                }
+              }
             ]
-        },
-        "deprecated": false
-    },
-    "deprecated": false
+          },
+          "deprecated": false
+        }
+      }
+    ]
+  },
+  "deprecated": false
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@types/express": "^4.17.14",
     "@types/node": "^18.7.18",
+    "openapi-types": "^12.0.2",
     "typescript": "^4.8.3"
   },
   "scripts": {

--- a/src/extractor/index.ts
+++ b/src/extractor/index.ts
@@ -64,7 +64,7 @@ const getVisitor = (
     // // We might brand DefineApiSpec, and access is branded using the type checker
 
     const output = resolve({ typeNode: node.type, current: { typeChecker } });
-    fs.writeFileSync("output.json", JSON.stringify(output, undefined, 4));
+    fs.writeFileSync("output.json", JSON.stringify(output, undefined, 2));
 
     // const specName = node.name.text;
     // const [specNode] = node.type.typeArguments ?? [];

--- a/src/extractor/typeResolver/index.ts
+++ b/src/extractor/typeResolver/index.ts
@@ -26,6 +26,12 @@ export const resolve = (params: Tspec.ResolveParamsBase): Tspec.Type => {
     };
   }
 
+  if (typeNode.kind === ts.SyntaxKind.NeverKeyword) {
+    return <Tspec.NeverType> {
+      typeName: 'never',
+    };
+  }
+
   if (ts.isArrayTypeNode(typeNode)) {
     return <Tspec.ArrayType>{
       typeName: 'array',
@@ -392,12 +398,12 @@ const resolveTypeReferenceNode = ({ typeNode, current, context, parentNode }: Ts
     }
 
     if (typeReference.typeName.text === 'Buffer') {
-      const bufferMetaType: Tspec.BufferType = { typeName: 'buffer' };
+      const bufferMetaType: Tspec.StringType = { typeName: 'string', format: 'binary' };
       return bufferMetaType;
     }
 
     if (typeReference.typeName.text === 'Readable') {
-      const streamMetaType: Tspec.BufferType = { typeName: 'buffer' };
+      const streamMetaType: Tspec.StringType = { typeName: 'string', format: 'binary' };
       return streamMetaType;
     }
 

--- a/src/openapi/getOpenApiType.ts
+++ b/src/openapi/getOpenApiType.ts
@@ -1,0 +1,139 @@
+import { OpenAPIV3 } from "openapi-types";
+import { Tspec } from "../types/tspec";
+import { assertNever } from '../utils';
+import { determineTypesUsedInEnum, getValue, groupEnums, hasUndefined, isNull, removeDuplicateOpenApiTypes } from "./utils";
+
+export const getOpenApiType = (type: Tspec.Type, title?: string): OpenAPIV3.SchemaObject => {
+  if (
+    type.typeName === 'void' || 
+    type.typeName === 'undefined' || 
+    type.typeName === 'never' || 
+    type.typeName === 'any'
+  ) {
+    return {}
+  } else if (type.typeName === 'boolean') {
+    return { type: type.typeName };
+  } else if (
+    type.typeName === 'integer' ||
+    type.typeName === 'number' ||
+    type.typeName === 'string'
+  ) {
+    return { type: type.typeName, format: type.format };
+  } else if (type.typeName === 'object') { // Tspec.ObjectsNoPropsType
+    return { type: 'object', additionalProperties: true }
+  } else if (type.typeName === 'array') {
+    return getOpenApiTypeForArrayType(type, title);
+  } else if (type.typeName === 'tuple') {
+    return getOpenApiTypeForTupleType(type);
+  } else if (type.typeName === 'intersection') {
+    return getOpenApiTypeForIntersectionType(type, title);
+  } else if (type.typeName === 'enum' || type.typeName === 'refEnum') {
+    return getOpenApiTypeForEnumType(type, title);
+  } else if (type.typeName === 'union') {
+    return getOpenApiTypeForUnionType(type, title);
+  } else if (type.typeName === 'nestedObjectLiteral' || type.typeName === 'refObject') {
+    return getOpenApiTypeForObjectLiteral(type, title);
+  } else if (type.typeName === 'refAlias') {
+    return getOpenApiType(type.type);
+  }
+  return assertNever(type.typeName);
+}
+
+const getOpenApiTypeForArrayType = (arrayType: Tspec.ArrayType, title?: string): OpenAPIV3.SchemaObject => {
+  return {
+    type: 'array',
+    items: getOpenApiType(arrayType.itemType, title),
+  };
+}
+
+const getOpenApiTypeForTupleType = (tupleType: Tspec.TupleType, title?: string): OpenAPIV3.SchemaObject => {
+  return {
+    type: 'array',
+    items: { // TODO: use prefixItems in OpenAPI 3.1. see https://stackoverflow.com/questions/57464633/how-to-define-a-json-array-with-concrete-item-definition-for-every-index-i-e-a
+      oneOf: tupleType.types.map((itemType) => getOpenApiType(itemType, title)),
+    },
+    minItems: tupleType.types.length,
+    maxItems: tupleType.types.length,
+  }
+}
+
+const getOpenApiTypeForIntersectionType = (type: Tspec.IntersectionType, title?: string): OpenAPIV3.SchemaObject => {
+  return { allOf: type.types.map(x => getOpenApiType(x)), ...(title && { title }) };
+}
+
+const getOpenApiTypeForEnumType = (enumType: Tspec.EnumType | Tspec.RefEnumType, title?: string): OpenAPIV3.SchemaObject => {
+  const types = determineTypesUsedInEnum(enumType.enums);
+
+  if (types.size === 1) {
+    const type = types.values().next().value;
+    const nullable = enumType.enums.some((e) => e === null) ? true : false;
+    return { ...(title && { title }), type, enum: enumType.enums.map(member => getValue(type, member)), nullable };
+  } else {
+    const valuesDelimited = Array.from(types).join(',');
+    throw new Error(`Enums can only have string or number values, but enum had ${valuesDelimited}`);
+  }
+}
+
+const getOpenApiTypeForUnionType = (unionType: Tspec.UnionType, title?: string): OpenAPIV3.SchemaObject => {
+  // Filter out nulls and undefineds
+  const actualOpenApiTypes = removeDuplicateOpenApiTypes(
+    groupEnums(
+      unionType.types
+        .filter((x) => !isNull(x))
+        .filter((x) => x.typeName !== 'undefined')
+        .map(x => getOpenApiType(x)),
+    ),
+  );
+  const nullable = unionType.types.some(x => isNull(x));
+
+  if (nullable) {
+    if (actualOpenApiTypes.length === 1) {
+      const [openApiType] = actualOpenApiTypes;
+      // for ref union with null, use an allOf with a single
+      // element since you can't attach nullable directly to a ref.
+      // https://swagger.io/docs/specification/using-ref/#syntax
+      // if (swaggerType.$ref) {
+      //   return { allOf: [swaggerType], nullable };
+      // }
+      return { title, ...openApiType, nullable };
+    } else {
+      return { title, anyOf: actualOpenApiTypes, nullable };
+    }
+  } else {
+    if (actualOpenApiTypes.length === 1) {
+      return { title, ...actualOpenApiTypes[0] };
+    } else {
+      return { title, anyOf: actualOpenApiTypes };
+    }
+  }
+}
+
+const getOpenApiTypeForObjectLiteral = (objectLiteral: Tspec.ObjectType, title?: string): OpenAPIV3.SchemaObject => {
+  const properties = buildProperties(objectLiteral.properties);
+  const additionalProperties = objectLiteral.additionalProperties && getOpenApiType(objectLiteral.additionalProperties);
+  const required = objectLiteral.properties.filter(prop => prop.required && !hasUndefined(prop)).map(prop => prop.name);
+
+  return {
+    title,
+    properties,
+    additionalProperties,
+    required: required.length > 0 ? required : undefined,
+    type: 'object',
+  };
+}
+
+const buildProperties = (source: Tspec.Property[]) => {
+  const properties: { [propertyName: string]: OpenAPIV3.SchemaObject } = {};
+
+  source.forEach(property => {
+    const openApiType = getOpenApiType(property.type);
+    openApiType.description = property.description;
+    openApiType.example = property.example;
+    openApiType.format = property.format || openApiType.format;
+    openApiType.deprecated = property.deprecated ? true : undefined;
+    properties[property.name] = openApiType;
+  });
+
+  return properties;
+}
+

--- a/src/openapi/index.ts
+++ b/src/openapi/index.ts
@@ -1,0 +1,102 @@
+import { OpenAPIV3 } from 'openapi-types';
+import { Tspec } from "../types/tspec";
+import { getOpenApiType } from './getOpenApiType';
+
+export const generateOpenApiSpec = (specs: Tspec.ParsedApiSpec[]): OpenAPIV3.Document => ({
+    openapi: '3.0.0',
+    info: {
+      title: 'API',
+      version: '1.0.0',
+    },
+    servers: [{ url: '/' }],
+    tags: buildTags(specs),
+    paths: buildPaths(specs),
+});
+
+const buildTags = (specs: Tspec.ParsedApiSpec[]): OpenAPIV3.TagObject[] => {
+  const tags = specs.map((spec) => spec.tags || []).flat();
+  const dedupedTags = [...new Set(tags)];
+  return dedupedTags.map((tag) => ({ name: tag }));
+}
+
+const buildPaths = (specs: Tspec.ParsedApiSpec[]): OpenAPIV3.PathsObject => {
+  const paths: OpenAPIV3.PathsObject = {};
+  const getPath = (pathName: string) => (paths[pathName] ||= {});
+
+  for (const spec of specs) {
+    const [method, pathName] = spec.url.split(' ');
+    const path = getPath(pathName);
+    const httpMethod = method.toLowerCase() as OpenAPIV3.HttpMethods;
+    path[httpMethod] = buildOperation(spec);
+  }
+
+  return paths;
+}
+
+const buildOperation = (spec: Tspec.ParsedApiSpec): OpenAPIV3.OperationObject => {
+  const { operationId, summary, description, tags, auth, path, query, body, response } = spec;
+  return {
+    tags,
+    summary,
+    description,
+    operationId,
+    parameters: buildParameters({ path, query }),
+    requestBody: buildRequestBody(body),
+    responses: buildResponses(response),
+    security: buildSecurity(auth),
+  };
+}
+
+const buildParameters = (
+  params: { path: Tspec.ParsedApiSpec['path'], query: Tspec.ParsedApiSpec['query']}
+): OpenAPIV3.ParameterObject[] | undefined => {
+  const pathParams = params.path?.type ? buildParametersByType('path', params.path.type) : [];
+  const queryParams = params.query?.type ? buildParametersByType('query', params.query.type) : [];
+  const parameters = [...pathParams, ...queryParams];
+  return parameters.length > 0 ? parameters : undefined;
+}
+
+const buildParametersByType = (
+  parameterType: 'path' | 'query', type: Tspec.ObjectType
+): OpenAPIV3.ParameterObject[] => {
+  return type.properties.map((property) => ({
+    name: property.name,
+    in: parameterType,
+    description: property.description,
+    required: parameterType === 'path' ? true : property.required,
+    deprecated: property.deprecated ? true : undefined,
+    schema: getOpenApiType(property.type),
+    example: property.example,
+  }));
+}
+
+const buildRequestBody = (body: Tspec.ParsedApiSpec['body']): OpenAPIV3.RequestBodyObject | undefined => {
+  if (!body) return undefined;
+  return {
+    description: body.description,
+    required: body.required,
+    content: {
+      'application/json': {
+        schema: getOpenApiType(body.type),
+      },
+    },
+  };
+}
+
+const buildResponses = (response: Tspec.ParsedApiSpec['response']): OpenAPIV3.ResponsesObject => {
+  return {
+    200: {
+      description: 'OK',
+      content: {
+        'application/json': {
+          schema: getOpenApiType(response.type),
+        },
+      },
+    },
+  };
+}
+
+const buildSecurity = (auth: Tspec.ParsedApiSpec['auth']): OpenAPIV3.SecurityRequirementObject[] | undefined => { 
+  if (!auth) return undefined;
+  return [{ [auth]: [] }];
+}

--- a/src/openapi/index.ts
+++ b/src/openapi/index.ts
@@ -2,21 +2,35 @@ import { OpenAPIV3 } from 'openapi-types';
 import { Tspec } from "../types/tspec";
 import { getOpenApiType } from './getOpenApiType';
 
-export const generateOpenApiSpec = (specs: Tspec.ParsedApiSpec[]): OpenAPIV3.Document => ({
+export const generateOpenApiSpec = (specs: Tspec.ParsedApiSpec[], override?: Partial<OpenAPIV3.Document>): OpenAPIV3.Document => ({
     openapi: '3.0.0',
     info: {
       title: 'API',
       version: '1.0.0',
+      ...override?.info,
     },
-    servers: [{ url: '/' }],
-    tags: buildTags(specs),
+    servers: override?.servers || [{ url: '/' }],
+    tags: buildTags(specs, override?.tags || []),
     paths: buildPaths(specs),
+    components: buildComponents(specs, override?.components || {}),
 });
 
-const buildTags = (specs: Tspec.ParsedApiSpec[]): OpenAPIV3.TagObject[] => {
-  const tags = specs.map((spec) => spec.tags || []).flat();
-  const dedupedTags = [...new Set(tags)];
-  return dedupedTags.map((tag) => ({ name: tag }));
+const buildTags = (specs: Tspec.ParsedApiSpec[], tags: OpenAPIV3.TagObject[]): OpenAPIV3.TagObject[] => {
+  const tagMap: Record<string, OpenAPIV3.TagObject> = {};
+
+  tags?.forEach((tag) => {
+    tagMap[tag.name] = tag;
+  });
+
+  specs.forEach((spec) => {
+    spec.tags?.forEach((tag) => {
+      if (!tagMap[tag]) {
+        tagMap[tag] = { name: tag };
+      }
+    });
+  });
+  
+  return Object.values(tagMap);
 }
 
 const buildPaths = (specs: Tspec.ParsedApiSpec[]): OpenAPIV3.PathsObject => {
@@ -31,6 +45,13 @@ const buildPaths = (specs: Tspec.ParsedApiSpec[]): OpenAPIV3.PathsObject => {
   }
 
   return paths;
+}
+
+const buildComponents = (specs: Tspec.ParsedApiSpec[], components: OpenAPIV3.ComponentsObject): OpenAPIV3.ComponentsObject => {
+  return {
+    // TODO: define schemas
+    securitySchemes: components.securitySchemes,
+  };
 }
 
 const buildOperation = (spec: Tspec.ParsedApiSpec): OpenAPIV3.OperationObject => {

--- a/src/openapi/utils.ts
+++ b/src/openapi/utils.ts
@@ -1,0 +1,85 @@
+import { OpenAPIV3 } from "openapi-types";
+import { Tspec } from "../types/tspec";
+
+export const getValue = (type: 'string' | 'number' | 'integer' | 'boolean', member: unknown): string | number | boolean | null => {
+  if (member === null) {
+    return null;
+  }
+
+  switch (type) {
+    case 'integer':
+    case 'number':
+      return Number(member);
+    case 'boolean':
+      return !!member;
+    case 'string':
+    default:
+      return String(member);
+  }
+}
+
+export const determineTypesUsedInEnum = (anEnum: Array<string | number | boolean | null>) => {
+  const typesUsedInEnum = anEnum.reduce((theSet, curr) => {
+    const typeUsed = curr === null ? 'number' : (typeof curr as 'string' | 'number' | 'boolean');
+    theSet.add(typeUsed);
+    return theSet;
+  }, new Set<'string' | 'number' | 'boolean'>());
+
+  return typesUsedInEnum;
+}
+
+export const removeDuplicateOpenApiTypes = (types: Array<OpenAPIV3.SchemaObject>): Array<OpenAPIV3.SchemaObject> => {
+  if (types.length === 1) {
+    return types;
+  } else {
+    const typesSet = new Set<string>();
+    for (const type of types) {
+      typesSet.add(JSON.stringify(type));
+    }
+    return Array.from(typesSet).map(typeString => JSON.parse(typeString));
+  }
+}
+
+
+export const isNull = (type: Tspec.Type) => {
+  return type.typeName === 'enum' && type.enums.length === 1 && type.enums[0] === null;
+}
+
+/**
+ * Join disparate enums with the same type into one.
+ * grouping enums is helpful because it makes the spec more readable and it
+ * bypasses a failure in openapi-generator caused by using anyOf with
+ * duplicate types.
+ */ 
+export const groupEnums = (types: Array<OpenAPIV3.SchemaObject>) => {
+  const returnTypes: Array<OpenAPIV3.SchemaObject> = [];
+  const enumValuesByType: any = {}; // FIXME any
+  for (const type of types) {
+    if (type.enum && type.type) {
+      for (const enumValue of type.enum) {
+        if (!enumValuesByType[type.type]) {
+          enumValuesByType[type.type] = [];
+        }
+        enumValuesByType[type.type][enumValue] = enumValue;
+      }
+    }
+    // preserve non-enum types
+    else {
+      returnTypes.push(type);
+    }
+  }
+
+  Object.keys(enumValuesByType).forEach(dataType =>
+    returnTypes.push({
+      type: dataType as any, // FIXME any
+      enum: Object.values(enumValuesByType[dataType]),
+    }),
+  );
+
+  return returnTypes;
+}
+
+export const hasUndefined = (property: Tspec.Property): boolean => {
+  return property.type.typeName === 'undefined' || (property.type.typeName === 'union' && property.type.types.some(type => type.typeName === 'undefined'));
+}
+

--- a/src/types/tspec.ts
+++ b/src/types/tspec.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { ApiSpec } from "./DefineApiSpec";
 
 export namespace Tspec {
   export type NumberFormat = 'int32' | 'int64' | 'float' | 'double';
@@ -16,7 +17,6 @@ export namespace Tspec {
     | 'undefined' 
     | 'any' 
     | 'intersection'  
-    | 'buffer'
     | 'nestedObjectLiteral'
     | 'object' 
     | 'array' 
@@ -45,7 +45,6 @@ export namespace Tspec {
     additionalProperties?: Type;
   }
   export interface ObjectsNoPropsType extends TypeBase { typeName: 'object' }
-  export interface BufferType extends TypeBase { typeName: 'buffer' }
 
   export interface Property {
     description?: string;
@@ -85,7 +84,13 @@ export namespace Tspec {
     typeName: 'refAlias';
   }
 
+  export interface NeverType extends TypeBase {
+    typeName: 'never'
+  }
+
   export type ReferenceType = RefEnumType | RefObjectType | RefAliasType;
+
+  export type ObjectType = NestedObjectLiteralType | RefObjectType;
 
   export type Type =
     | PrimitiveType
@@ -93,14 +98,14 @@ export namespace Tspec {
     | EnumType
     | ArrayType
     | TupleType
-    | BufferType
     | AnyType
     | RefEnumType
     | RefObjectType
     | RefAliasType
     | NestedObjectLiteralType
     | UnionType
-    | IntersectionType;
+    | IntersectionType
+    | NeverType;
 
   export interface Context {
     [name: string]: ts.TypeReferenceNode | ts.TypeNode;
@@ -150,5 +155,13 @@ export namespace Tspec {
   
   export type UsableDeclaration = ts.InterfaceDeclaration | ts.ClassDeclaration | ts.PropertySignature | ts.TypeAliasDeclaration | ts.EnumMember;
   export type UsableDeclarationWithoutPropertySignature = Exclude<UsableDeclaration, ts.PropertySignature>;
+
+  export interface ParsedApiSpec extends ApiSpec {
+    operationId: string,
+    path?: Tspec.Property & { type: Tspec.ObjectType },
+    query?: Tspec.Property & { type: Tspec.ObjectType },
+    body?: Tspec.Property & { type: Tspec.ObjectType },
+    response: Tspec.Property & { type: Tspec.ObjectType },
+  }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export const assertNever = (x: never): never => {
+  throw new Error("Was not never: " + x);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,6 +69,11 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+openapi-types@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.0.2.tgz#b752ab0a463c594fd7e3142e0e5983a9645503f6"
+  integrity sha512-GuTo7FyZjOIWVhIhQSWJVaws6A82sWIGyQogxxYBYKZ0NBdyP2CYSIgOwFfSB+UVoPExk/YzFpyYitHS8KVZtA==
+
 typescript@^4.8.3:
   version "4.8.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz"


### PR DESCRIPTION
## Input
```ts
export const mockSpec: Tspec.ParsedApiSpec = {
  operationId: 'GetSeries',
  url: 'GET /manta/v1/series/{id}',
  summary: 'Retrieve a series',
  description: 'Retrieve a series',
  tags: ['Series', 'Front'],
  auth: 'JWT',
  path: {
    "deprecated": false,
    "name": "path",
    "required": true,
    "type": {
      "typeName": "nestedObjectLiteral",
      "properties": [
        {
          "example": 1255,
          "description": "Series id",
          "deprecated": false,
          "name": "id",
          "required": true,
          "type": {
            "typeName": "number"
          }
        }
      ]
    }
  },
  query: {
    "deprecated": false,
    "name": "query",
    "required": true,
    "type": {
      "typeName": "nestedObjectLiteral",
      "properties": [
        {
          "deprecated": false,
          "name": "debug",
          "required": false,
          "type": {
            "typeName": "boolean"
          }
        }
      ]
    }
  },
  response: {
    "deprecated": false,
    "name": "response",
    "required": true,
    "type": {
      "typeName": "nestedObjectLiteral",
      "properties": [
        {
          "deprecated": false,
          "name": "id",
          "required": true,
          "type": {
            "typeName": "number"
          }
        },
        {
          "deprecated": false,
          "name": "thumbnail",
          "required": true,
          "type": {
            "typeName": "refAlias",
            "refName": "Thumbnail",
            "type": {
              "typeName": "nestedObjectLiteral",
              "properties": [
                {
                  "deprecated": false,
                  "name": "xlarge",
                  "required": true,
                  "type": {
                    "typeName": "string"
                  }
                }
              ]
            },
            "deprecated": false
          }
        }
      ]
    }
  }
};
generateOpenApiSpec([mockSpec]);
```

## Output
```json
{
  "openapi": "3.0.0",
  "info": {
    "title": "API",
    "version": "1.0.0"
  },
  "servers": [
    {
      "url": "/"
    }
  ],
  "tags": [
    {
      "name": "Series"
    },
    {
      "name": "Front"
    }
  ],
  "paths": {
    "/manta/v1/series/{id}": {
      "get": {
        "tags": [
          "Series",
          "Front"
        ],
        "summary": "Retrieve a series",
        "description": "Retrieve a series",
        "operationId": "GetSeries",
        "parameters": [
          {
            "name": "id",
            "in": "path",
            "description": "Series id",
            "required": true,
            "schema": {
              "type": "number"
            },
            "example": 1255
          },
          {
            "name": "debug",
            "in": "query",
            "required": false,
            "schema": {
              "type": "boolean"
            }
          }
        ],
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "properties": {
                    "id": {
                      "type": "number"
                    },
                    "thumbnail": {
                      "properties": {
                        "xlarge": {
                          "type": "string"
                        }
                      },
                      "required": [
                        "xlarge"
                      ],
                      "type": "object"
                    }
                  },
                  "required": [
                    "id",
                    "thumbnail"
                  ],
                  "type": "object"
                }
              }
            }
          }
        },
        "security": [
          {
            "JWT": []
          }
        ]
      }
    }
  }
}
```