### PR TITLE
Add file method for CLI configuration

### DIFF
--- a/packages/tspec/src/cli/config/index.ts
+++ b/packages/tspec/src/cli/config/index.ts
@@ -5,12 +5,23 @@ import { Tspec } from 'types/tspec';
 
 const TSPEC_CONFIG_FILE_NAME = 'tspec.config.json';
 
-// Try to find tspec config json file where tspec cli has been executed.
-const getTspecDefaultPath = () => path.join(process.cwd(), TSPEC_CONFIG_FILE_NAME);
+const readTspecConfig = (path: string) => {
+  try {
+    return fs.readFile(path, { encoding: 'utf8' });
+  } catch (err) {
+    console.error('Cannot read Tspec config');
+    throw err;
+  }
+};
 
-const readTspecConfig = (path: string) => fs.readFile(path, { encoding: 'utf8' });
-
-const parseTspecConfig = (config: string) => JSON.parse(config);
+const parseTspecConfig = (config: string) => {
+  try {
+    return JSON.parse(config);
+  } catch (err) {
+    console.error('Cannot parse Tspec config');
+    throw err;
+  }
+};
 
 const validateTspecConfig = (config: any) => {
   try {
@@ -21,9 +32,24 @@ const validateTspecConfig = (config: any) => {
   }
 };
 
-export const getTspecConfigFromConfigFile = async (inputPath?: string) => {
-  const path = inputPath ?? getTspecDefaultPath();
-  const fileResult = await readTspecConfig(path);
+const getConfigPath = (inputPath?: string) => {
+  const filePath = inputPath || TSPEC_CONFIG_FILE_NAME;
+  return path.join(process.cwd(), filePath);
+};
+
+export const isTspecFileConfigAvailable = async (
+  inputPath?: string,
+) => {
+  const configPath = getConfigPath(inputPath);
+  return (await fs.stat(configPath)).isFile();
+};
+
+export const getTspecConfigFromConfigFile = async (
+  inputPath?: string,
+): Promise<Tspec.GenerateParams> => {
+  const configPath = getConfigPath(inputPath);
+  const fileResult = await readTspecConfig(configPath);
+
   const unreliableConfig = parseTspecConfig(fileResult);
   const config = validateTspecConfig(unreliableConfig);
 

--- a/packages/tspec/src/cli/config/index.ts
+++ b/packages/tspec/src/cli/config/index.ts
@@ -1,0 +1,31 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import { Tspec } from 'types/tspec';
+
+const TSPEC_CONFIG_FILE_NAME = 'tspec.config.json';
+
+// Try to find tspec config json file where tspec cli has been executed.
+const getTspecDefaultPath = () => path.join(process.cwd(), TSPEC_CONFIG_FILE_NAME);
+
+const readTspecConfig = (path: string) => fs.readFile(path, { encoding: 'utf8' });
+
+const parseTspecConfig = (config: string) => JSON.parse(config);
+
+const validateTspecConfig = (config: any) => {
+  try {
+    // TODO: validate whether config JSON is fit with GenerateParams or not.
+    return config as Tspec.GenerateParams;
+  } catch (err) {
+    throw new Error('validateTspecConfig: Unimplemented');
+  }
+};
+
+export const getTspecConfigFromConfigFile = async (inputPath?: string) => {
+  const path = inputPath ?? getTspecDefaultPath();
+  const fileResult = await readTspecConfig(path);
+  const unreliableConfig = parseTspecConfig(fileResult);
+  const config = validateTspecConfig(unreliableConfig);
+
+  return config;
+};


### PR DESCRIPTION
## Changes
* File method(name with `tspec.config.json`) for CLI configration has been added.

## TODOs
- [x] Validation for `tspec.config.json` → need to use `typescript-json-schema`.