### PR TITLE
[bug-fix] Fix bugs related to mediaType

### DIFF
--- a/packages/tspec/src/generator/index.ts
+++ b/packages/tspec/src/generator/index.ts
@@ -156,16 +156,19 @@ const getOpenapiSchemasOnly = (openapiSchemas: SchemaMapping, tspecSymbols: stri
     });
   });
 
+  const isTspecSchema = (key: string) => (
+    tspecSymbols.includes(key) || tspecPathSchemas.includes(key)
+  )
+
+  const omitPathSchemaFields = (schema: OpenAPIV3.SchemaObject & { mediaType?: string }) => {
+    const { mediaType, ...rest } = schema;
+    return rest;
+  }
+
   return Object.fromEntries(
     Object.entries(openapiSchemas)
-      .filter(
-        ([key]) =>
-          !tspecSymbols.includes(key) && !tspecPathSchemas.includes(key)
-      )
-      .map(([key, value]: [key: string, value: OpenAPIV3.SchemaObject & {mediaType?: string} ]) => {
-        const { mediaType = "", ...body } = value || {};
-        return [key, body];
-      })
+      .filter(([key]) => !isTspecSchema(key))
+      .map(([key, value]) => [key, omitPathSchemaFields(value)]),
   );
 };
 

--- a/packages/tspec/src/generator/index.ts
+++ b/packages/tspec/src/generator/index.ts
@@ -157,9 +157,15 @@ const getOpenapiSchemasOnly = (openapiSchemas: SchemaMapping, tspecSymbols: stri
   });
 
   return Object.fromEntries(
-    Object.entries(openapiSchemas).filter(
-      ([key]) => (!tspecSymbols.includes(key) && !tspecPathSchemas.includes(key)),
-    ),
+    Object.entries(openapiSchemas)
+      .filter(
+        ([key]) =>
+          !tspecSymbols.includes(key) && !tspecPathSchemas.includes(key)
+      )
+      .map(([key, value]: [key: string, value: OpenAPIV3.SchemaObject & {mediaType?: string} ]) => {
+        const { mediaType = "", ...body } = value || {};
+        return [key, body];
+      })
   );
 };
 

--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -108,7 +108,7 @@ export const getOpenapiPaths = (
     const queryParams = getObjectPropertyByPath(spec, 'query', openapiSchemas) as any;
     const headerParams = getObjectPropertyByPath(spec, 'header', openapiSchemas) as any;
     const cookieParams = getObjectPropertyByPath(spec, 'cookie', openapiSchemas) as any;
-    const { mediaType = '', ...bodyParams } = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any || {};
+    const bodyParams = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any;
 
     const operation = {
       operationId: `${controllerName}_${method}_${path}`,
@@ -126,7 +126,7 @@ export const getOpenapiPaths = (
         description: bodyParams.description,
         required: true,
         content: {
-          [mediaType || 'application/json']: {
+          [bodyParams?.mediaType || 'application/json']: {
             schema: bodyParams,
           },
         },

--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -108,8 +108,7 @@ export const getOpenapiPaths = (
     const queryParams = getObjectPropertyByPath(spec, 'query', openapiSchemas) as any;
     const headerParams = getObjectPropertyByPath(spec, 'header', openapiSchemas) as any;
     const cookieParams = getObjectPropertyByPath(spec, 'cookie', openapiSchemas) as any;
-
-    const { mediaType = '', ...bodyParams } = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any;
+    const { mediaType = '', ...bodyParams } = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any || {};
 
     const operation = {
       operationId: `${controllerName}_${method}_${path}`,


### PR DESCRIPTION

# Describe bug

Issues can arise in the following two scenarios
1. When there is no request body in the API Spec, it leads to failed OAS generation.
2. When the `mediaType` is specified above the request body or response body, it results in the generation of an invalid OAS.

# Reproduction
## Version
0.1.105

## Case 1: If API spec does not have a body

### Schema
```ts
type TestApiSpec = Tspec.DefineApiSpec<{
  basePath: "/test";
  tags: ["Test"];
  paths: {
    "/": {
      get: {
        summary: "Simple test";
        responses: {
          200: {};
        };
      };
    };
  };
}>;
```

### Result
Failed to generate OAS
```zsh
/Users/gimseong-won/coding/tspec/packages/tspec/src/generator/openapiGenerator.ts:112
    const { mediaType = '', ...bodyParams } = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any;
            ^


TypeError: Cannot read properties of undefined (reading 'mediaType')
    at <anonymous> (/Users/gimseong-won/coding/tspec/packages/tspec/src/generator/openapiGenerator.ts:112:13)
    at Array.forEach (<anonymous>)
    at getOpenapiPaths (/Users/gimseong-won/coding/tspec/packages/tspec/src/generator/openapiGenerator.ts:90:9)
    at generateTspec (/Users/gimseong-won/coding/tspec/packages/tspec/src/generator/index.ts:177:17)
    at <anonymous> (/Users/gimseong-won/coding/tspec/packages/tspec/schema.ts:45:1)
```

## Case 2: If `mediaType` are specified above the request or response

### Schema
``` ts
/** @mediaType application/json */
interface TestRequest {
  message?: string;
}

/** @mediaType application/json */
interface TestResponse {
    message: string;
}

type TestApiSpec = Tspec.DefineApiSpec<{
  basePath: "/test";
  tags: ["Test"];
  paths: {
    "/": {
      get: {
        summary: "Simple test";
        body: TestRequest;
        responses: {
          200: TestResponse;
        };
      };
    };
  };
}>;
```


### Result
An invalid OAS is generated, which includes  `mediaType` property
 ``` json
{
  "info": {
    "title": "Test for Tspec",
    "version": "1.0.0"
  },
  "openapi": "3.0.3",
  "paths": {
    "/test/": {
      "get": {
        "operationId": "TestApiSpec_get_/",
        "tags": [
          "Test"
        ],
        "summary": "Simple test",
        "parameters": [],
        "requestBody": {
          "required": true,
          "content": {
            "application/json": {
              "schema": {
                "type": "object",
                "properties": {
                  "message": {
                    "type": "string"
                  }
                },
                "additionalProperties": false
              }
            }
          }
        },
        "responses": {
          "200": {
            "description": "",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/TestResponse"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "TestRequest": {
        "mediaType": "application/json",
        "type": "object",
        "properties": {
          "message": {
            "type": "string"
          }
        },
        "additionalProperties": false
      },
      "TestResponse": {
        "mediaType": "application/json",
        "type": "object",
        "properties": {
          "message": {
            "type": "string"
          }
        },
        "additionalProperties": false,
        "required": [
          "message"
        ]
      }
    }
  }
}
```

# Changes
1. Handle cases where the body is `undefined` when the `schema` lacks body data.
2. Exclude the `mediaType` property when obtaining data of `schema` type.

The code in change 2 were made solely to fix a bug, without considering the package architecture. As a result, they might need to be refactored to align with the architecture (TODO).

# Suggestion
I believe your team needs test code. When developing a new feature, it's also crucial to ensure that it doesn't have any adverse effects on the existing features.