### PR TITLE
[bug-fix] Filter out mediaType from bodyParams

### DIFF
--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -67,6 +67,11 @@ const resolveParameters = ({ path, query, header, cookie }: ResolveParametersPar
   return [...pathParams, ...queryParams, ...headerParams, ...cookieParams];
 };
 
+const convertEmptyObjectToUndefined = (obj: SchemaMapping) => {
+  if (Object.keys(obj).length == 0) return undefined
+  return obj
+}
+
 export const getOpenapiPaths = (
   openapiSchemas: SchemaMapping,
   tspecSymbols: string[],
@@ -108,8 +113,8 @@ export const getOpenapiPaths = (
     const queryParams = getObjectPropertyByPath(spec, 'query', openapiSchemas) as any;
     const headerParams = getObjectPropertyByPath(spec, 'header', openapiSchemas) as any;
     const cookieParams = getObjectPropertyByPath(spec, 'cookie', openapiSchemas) as any;
-    const bodyParams = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any;
-
+    const {mediaType = '', ...bodyParams} = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any || {};
+    
     const operation = {
       operationId: `${controllerName}_${method}_${path}`,
       tags,
@@ -122,13 +127,13 @@ export const getOpenapiPaths = (
         header: headerParams,
         cookie: cookieParams,
       }),
-      requestBody: bodyParams && {
+      requestBody: convertEmptyObjectToUndefined(bodyParams) && {
         description: bodyParams.description,
         required: true,
         content: {
-          [bodyParams?.mediaType || 'application/json']: {
-            schema: bodyParams,
-          },
+          [mediaType || 'application/json']: {
+            schema: bodyParams
+          }
         },
       },
       responses: Object.fromEntries(

--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -67,9 +67,9 @@ const resolveParameters = ({ path, query, header, cookie }: ResolveParametersPar
   return [...pathParams, ...queryParams, ...headerParams, ...cookieParams];
 };
 
-const convertEmptyObjectToUndefined = (obj: SchemaMapping) => {
-  if (Object.keys(obj).length == 0) return undefined
-  return obj
+const omitPathSchemaFields = (schema: OpenAPIV3.SchemaObject & { mediaType?: string }) => {
+  const { mediaType, ...rest } = schema;
+  return rest;
 }
 
 export const getOpenapiPaths = (
@@ -113,7 +113,7 @@ export const getOpenapiPaths = (
     const queryParams = getObjectPropertyByPath(spec, 'query', openapiSchemas) as any;
     const headerParams = getObjectPropertyByPath(spec, 'header', openapiSchemas) as any;
     const cookieParams = getObjectPropertyByPath(spec, 'cookie', openapiSchemas) as any;
-    const {mediaType = '', ...bodyParams} = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any || {};
+    const bodyParams = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any;
     
     const operation = {
       operationId: `${controllerName}_${method}_${path}`,
@@ -127,12 +127,12 @@ export const getOpenapiPaths = (
         header: headerParams,
         cookie: cookieParams,
       }),
-      requestBody: convertEmptyObjectToUndefined(bodyParams) && {
+      requestBody: bodyParams && {
         description: bodyParams.description,
         required: true,
         content: {
-          [mediaType || 'application/json']: {
-            schema: bodyParams
+          [bodyParams?.mediaType || 'application/json']: {
+            schema: omitPathSchemaFields(bodyParams),
           }
         },
       },

--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -114,7 +114,7 @@ export const getOpenapiPaths = (
     const headerParams = getObjectPropertyByPath(spec, 'header', openapiSchemas) as any;
     const cookieParams = getObjectPropertyByPath(spec, 'cookie', openapiSchemas) as any;
     const bodyParams = getObjectPropertyByPath(spec, 'body', openapiSchemas) as any;
-    
+
     const operation = {
       operationId: `${controllerName}_${method}_${path}`,
       tags,

--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -133,7 +133,7 @@ export const getOpenapiPaths = (
         content: {
           [bodyParams?.mediaType || 'application/json']: {
             schema: omitPathSchemaFields(bodyParams),
-          }
+          },
         },
       },
       responses: Object.fromEntries(


### PR DESCRIPTION
# Related PR
#34, #35 

# Changes

1. Filter out `mediaType` from `bodyParams`. (If you enter a `mediaType` as a subproperty of `bodyParams`, the generated OAS will also contain the `mediaType`, resulting in an invalid OAS, which should be filtered out. [problem detail](https://github.com/ts-spec/tspec/pull/34))
2. When `bodyParams` are empty, convert empty object to `undefined`.