### PR TITLE
fix: empty responses fallback

### DIFF
--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -107,8 +107,7 @@ export const getOpenapiPaths = (
       spec,
       'responses',
       openapiSchemas,
-      { required: true },
-    )!;
+    ) || { properties: {} };
 
     const pathParams = getObjectPropertyByPath(spec, 'path', openapiSchemas) as any;
     const queryParams = getObjectPropertyByPath(spec, 'query', openapiSchemas) as any;
@@ -141,11 +140,12 @@ export const getOpenapiPaths = (
         Object.keys(responses.properties).map((code) => {
           const schema = getPropertyByPath(responses, code, openapiSchemas);
           const { description = '', mediaType } = schema as any;
+          const contentSchema = responses.properties[code];
           const resSchema = {
             description,
             content: {
               [mediaType || 'application/json']: {
-                schema: responses.properties[code],
+                schema: contentSchema,
               },
             },
           };


### PR DESCRIPTION
fix the bug where an empty responses object causes an error

ex)
### Schema
```ts
export type BookApiSpec = Tspec.DefineApiSpec<{
  paths: {
    '/':  {
      get: {
        responses: { 200: never },
      },
    },
  }
}>;
```

### Error
Error: Invalid 'responses' in {"additionalProperties":false,"type":"object","properties":{"responses":{"type":"object","additionalProperties":false},"__handler":{},"method":{"type":"string","enum":["get"]},"url":{"type":"string","enum":["/"]},"security":{},"tags":{"type":"array","minItems":0,"maxItems":0}},"required":["__handler","method","responses","security","tags","url"]}; value: {"type":"object","additionalProperties":false}


