### PR TITLE
feat: allow JSDoc comments to override response descriptions

### DIFF
--- a/packages/tspec/src/generator/openapiGenerator.ts
+++ b/packages/tspec/src/generator/openapiGenerator.ts
@@ -150,14 +150,18 @@ export const getOpenapiPaths = (
       responses: Object.fromEntries(
         Object.keys(responses.properties).map((code) => {
           const schema = getPropertyByPath(responses, code, openapiSchemas);
-          const { description = '', mediaType } = schema as any;
-          const contentSchema = responses.properties[code];
+          const { mediaType } = schema as any;
+          const contentSchema = responses.properties[code] as any;
           const isNoContent = isNoContentSchema(contentSchema);
+          // Use JSDoc description from contentSchema, fallback to resolved schema description
+          const description = contentSchema?.description || (schema as any)?.description || '';
+          // Remove description from schema to avoid duplication in output
+          const { description: _, ...cleanContentSchema } = contentSchema || {};
           const resSchema = {
             description,
             content: isNoContent ? undefined : {
               [mediaType || 'application/json']: {
-                schema: contentSchema,
+                schema: cleanContentSchema,
               },
             },
           };

--- a/packages/tspec/src/test/scenarios/response-description/expected.json
+++ b/packages/tspec/src/test/scenarios/response-description/expected.json
@@ -1,0 +1,72 @@
+{
+  "info": {
+    "title": "Tspec API",
+    "version": "0.0.1",
+    "description": ""
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/tasks/{id}": {
+      "delete": {
+        "operationId": "ResponseDescriptionApiSpec_delete_/tasks/{id}",
+        "tags": [],
+        "summary": "Delete a task",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Task deleted successfully"
+          },
+          "400": {
+            "description": "Invalid parameters provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/packages/tspec/src/test/scenarios/response-description/spec.ts
+++ b/packages/tspec/src/test/scenarios/response-description/spec.ts
@@ -1,0 +1,30 @@
+import { Tspec } from '../../../types/tspec';
+
+interface Task {
+  id: number;
+  title: string;
+}
+
+interface ErrorResponse {
+  code: string;
+  message: string;
+}
+
+export type ResponseDescriptionApiSpec = Tspec.DefineApiSpec<{
+  paths: {
+    '/tasks/{id}': {
+      delete: {
+        summary: 'Delete a task';
+        path: { id: number };
+        responses: {
+          /** Task deleted successfully */
+          204: Tspec.NoContent;
+          /** Invalid parameters provided */
+          400: ErrorResponse;
+          /** Task not found */
+          404: ErrorResponse;
+        };
+      };
+    };
+  };
+}>;


### PR DESCRIPTION
## Summary
Fixes #55

Allows JSDoc comments on response status codes to override the response description in the generated OpenAPI spec.

## Problem
Previously, the response description was taken from the resolved schema's description, which might not accurately represent the actual response description for that specific endpoint.

## Solution
- Extract JSDoc description from the raw `contentSchema` (which contains the JSDoc comment)
- Fall back to the resolved schema description if no JSDoc comment is present
- Remove the description from the schema to avoid duplication in the output

## Example
```typescript
export type ApiSpec = Tspec.DefineApiSpec<{
  paths: {
    '/tasks/{id}': {
      delete: {
        summary: 'Delete a task';
        path: { id: number };
        responses: {
          /** Task deleted successfully */
          204: Tspec.NoContent;
          /** Invalid parameters provided */
          400: ErrorResponse;
          /** Task not found */
          404: ErrorResponse;
        };
      };
    };
  };
}>;
```

Now correctly generates:
```json
{
  "responses": {
    "204": {
      "description": "Task deleted successfully"
    },
    "400": {
      "description": "Invalid parameters provided",
      "content": { ... }
    },
    "404": {
      "description": "Task not found",
      "content": { ... }
    }
  }
}
```

## Changes
- `packages/tspec/src/generator/openapiGenerator.ts`: Extract JSDoc description from contentSchema
- Added `response-description` test scenario