### PR TITLE
feat(nestjs): enhance parser with @ApiTags, type definitions, and enum support

### DIFF
--- a/packages/tspec/src/nestjs/types.ts
+++ b/packages/tspec/src/nestjs/types.ts
@@ -5,6 +5,7 @@ export interface NestControllerMetadata {
   path: string;
   filePath: string;
   methods: NestMethodMetadata[];
+  tags?: string[]; // From @ApiTags decorator
 }
 
 export interface NestMethodMetadata {
@@ -35,4 +36,27 @@ export interface NestParserOptions {
 export interface ParsedNestApp {
   controllers: NestControllerMetadata[];
   imports: Map<string, string>; // typeName -> import path
+  typeDefinitions: Map<string, TypeDefinition>; // typeName -> type definition
+  enumDefinitions: Map<string, EnumDefinition>; // enumName -> enum definition
+}
+
+export interface EnumDefinition {
+  name: string;
+  values: string[];
+  description?: string;
+}
+
+export interface TypeDefinition {
+  name: string;
+  properties: PropertyDefinition[];
+  description?: string;
+}
+
+export interface PropertyDefinition {
+  name: string;
+  type: string;
+  required: boolean;
+  description?: string;
+  isArray?: boolean;
+  enumValues?: string[];
 }


### PR DESCRIPTION
## Summary

Enhances the NestJS parser to support richer metadata collection for OpenAPI generation.

## Changes

### @ApiTags Decorator Parsing
- Parse `@ApiTags` decorator from controllers to extract tags
- Support various formats: string literals, enum values, and variable references

### Type Definition Collection
- Collect type definitions from classes, interfaces, and type aliases
- Parse property information (name, type, required, description)
- Support generic types (e.g., `DataResponse<T>`)

### Enum Definition Parsing
- Extract values from enum declarations
- Support string/numeric literals and implicit values

### Other Improvements
- Support array type parsing (`T[]`, `Array<T>`)
- Add helper functions for type name collection
- Add `tags` field to `NestControllerMetadata`
- Add `typeDefinitions` and `enumDefinitions` to `ParsedNestApp`

## Files Changed
- `packages/tspec/src/nestjs/parser.ts` - Enhanced parser logic
- `packages/tspec/src/nestjs/types.ts` - New type definitions
- `packages/tspec/src/nestjs/openapiGenerator.ts` - Utilize type definitions