### PR TITLE
feat(nestjs): add programmatic API for generating OpenAPI spec

### DIFF
--- a/packages/tspec/src/index.ts
+++ b/packages/tspec/src/index.ts
@@ -1,3 +1,4 @@
 export * from './generator';
 export * from './server';
 export * from './types';
+export * from './nestjs';

--- a/packages/tspec/src/nestjs/index.ts
+++ b/packages/tspec/src/nestjs/index.ts
@@ -1,3 +1,9 @@
+import type { OpenAPIV3 } from 'openapi-types';
+import { parseNestControllers } from './parser';
+import { generateOpenApiFromNest } from './openapiGenerator';
+import type { GenerateOpenApiOptions } from './openapiGenerator';
+import type { NestParserOptions } from './types';
+
 export { parseNestControllers } from './parser';
 export { generateOpenApiFromNest } from './openapiGenerator';
 export type {
@@ -9,3 +15,42 @@ export type {
   HttpMethod,
 } from './types';
 export type { GenerateOpenApiOptions } from './openapiGenerator';
+
+/**
+ * Options for generating OpenAPI spec from NestJS controllers
+ */
+export interface GenerateNestTspecOptions {
+  /** Path to tsconfig.json */
+  tsconfigPath?: string;
+  /** Glob patterns for controller files */
+  controllerGlobs?: string[];
+  /** OpenAPI document options */
+  openapi?: GenerateOpenApiOptions;
+}
+
+/**
+ * Generate OpenAPI spec from NestJS controllers programmatically
+ * 
+ * @example
+ * ```typescript
+ * import { generateNestTspec } from 'tspec';
+ * 
+ * const spec = generateNestTspec({
+ *   tsconfigPath: './tsconfig.json',
+ *   controllerGlobs: ['src/**\/*.controller.ts'],
+ *   openapi: {
+ *     title: 'My API',
+ *     version: '1.0.0',
+ *   },
+ * });
+ * ```
+ */
+export const generateNestTspec = (options: GenerateNestTspecOptions = {}): OpenAPIV3.Document => {
+  const parserOptions: NestParserOptions = {
+    tsconfigPath: options.tsconfigPath || './tsconfig.json',
+    controllerGlobs: options.controllerGlobs || ['src/**/*.controller.ts'],
+  };
+
+  const app = parseNestControllers(parserOptions);
+  return generateOpenApiFromNest(app, options.openapi || {});
+};


### PR DESCRIPTION
## Summary

Adds a programmatic API for generating OpenAPI specs from NestJS controllers.

## Changes

### New `generateNestTspec` Function
- Provides a simple, single-function API for generating OpenAPI specs
- Configurable options for tsconfig path, controller globs, and OpenAPI metadata

### Export NestJS Module
- Export nestjs module from main tspec entry point (`tspec`)
- Users can now import directly: `import { generateNestTspec } from 'tspec'`

## Usage

```typescript
import { generateNestTspec } from 'tspec';

const spec = generateNestTspec({
  tsconfigPath: './tsconfig.json',
  controllerGlobs: ['src/**/*.controller.ts'],
  openapi: {
    title: 'My API',
    version: '1.0.0',
  },
});
```

## Files Changed
- `packages/tspec/src/index.ts` - Export nestjs module
- `packages/tspec/src/nestjs/index.ts` - Add `generateNestTspec` function and options interface