### PR TITLE
feat(nestjs): add JSDoc tags support for property schema generation

### DIFF
--- a/packages/tspec/src/nestjs/types.ts
+++ b/packages/tspec/src/nestjs/types.ts
@@ -59,4 +59,14 @@ export interface PropertyDefinition {
   description?: string;
   isArray?: boolean;
   enumValues?: string[];
+  example?: unknown;
+  format?: string;
+  deprecated?: boolean;
+  nullable?: boolean;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  default?: unknown;
 }


### PR DESCRIPTION
## Summary

Adds support for parsing JSDoc tags on type properties and merging them into OpenAPI schema generation.

## Supported JSDoc Tags

| Tag | Description | Example |
|-----|-------------|---------|
| `@example` | Example value (JSON or string) | `@example "john@example.com"` |
| `@format` | OpenAPI format | `@format email` |
| `@deprecated` | Mark as deprecated | `@deprecated` |
| `@nullable` | Allow null values | `@nullable` |
| `@minimum` | Minimum numeric value | `@minimum 0` |
| `@maximum` | Maximum numeric value | `@maximum 100` |
| `@minLength` | Minimum string length | `@minLength 1` |
| `@maxLength` | Maximum string length | `@maxLength 255` |
| `@pattern` | Regex pattern | `@pattern ^[a-z]+$` |
| `@default` | Default value | `@default "active"` |

## Usage Example

```ts
interface CreateUserDto {
  /**
   * User's email address
   * @format email
   * @example "user@example.com"
   */
  email: string;

  /**
   * User's age
   * @minimum 0
   * @maximum 150
   */
  age: number;

  /**
   * @deprecated Use 'username' instead
   */
  name?: string;
}
```

## Files Changed
- `packages/tspec/src/nestjs/parser.ts` - Add `getJsDocTags` function to parse JSDoc tags
- `packages/tspec/src/nestjs/types.ts` - Extend `PropertyDefinition` with JSDoc tag fields
- `packages/tspec/src/nestjs/openapiGenerator.ts` - Merge JSDoc tags into OpenAPI schema