### PR TITLE
test: add CLI and generator function tests

### DIFF
--- a/packages/tspec/src/test/cli.test.ts
+++ b/packages/tspec/src/test/cli.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { generateTspec } from '../generator';
+import { generateNestTspec } from '../nestjs';
+import type { Tspec } from '../types/tspec';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const FIXTURES_DIR = path.join(__dirname, 'nestjs/fixtures');
+const SCENARIOS_DIR = path.join(__dirname, 'scenarios');
+const OUTPUT_DIR = path.join(__dirname, 'output');
+
+describe('CLI and Generate Function', () => {
+  beforeAll(async () => {
+    await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(OUTPUT_DIR, { recursive: true, force: true });
+  });
+
+  describe('generateTspec', () => {
+    it('should generate OpenAPI spec with default options', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+      });
+
+      expect(spec).toBeDefined();
+      expect(spec.openapi).toBe('3.0.3');
+      expect(spec.info).toBeDefined();
+      expect(spec.paths).toBeDefined();
+    });
+
+    it('should use custom openapi options', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        openapi: {
+          title: 'Custom API Title',
+          version: '2.0.0',
+          description: 'Custom description',
+        },
+      });
+
+      expect(spec.info.title).toBe('Custom API Title');
+      expect(spec.info.version).toBe('2.0.0');
+      expect(spec.info.description).toBe('Custom description');
+    });
+
+    it('should include securityDefinitions in components', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        openapi: {
+          title: 'API with Security',
+          version: '1.0.0',
+          securityDefinitions: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+              bearerFormat: 'JWT',
+            },
+          },
+        },
+      });
+
+      expect(spec.components?.securitySchemes).toBeDefined();
+      expect(spec.components?.securitySchemes?.bearerAuth).toEqual({
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      });
+    });
+
+    it('should include servers in spec', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        openapi: {
+          title: 'API with Servers',
+          version: '1.0.0',
+          servers: [
+            { url: 'https://api.example.com', description: 'Production' },
+            { url: 'https://staging.example.com', description: 'Staging' },
+          ],
+        },
+      });
+
+      expect(spec.servers).toBeDefined();
+      expect(spec.servers).toHaveLength(2);
+      expect(spec.servers?.[0].url).toBe('https://api.example.com');
+      expect(spec.servers?.[1].url).toBe('https://staging.example.com');
+    });
+
+    it('should write output file when outputPath is provided', async () => {
+      const outputPath = path.join(OUTPUT_DIR, 'test-output.json');
+
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        outputPath,
+      });
+
+      const fileExists = await fs.access(outputPath).then(() => true).catch(() => false);
+      expect(fileExists).toBe(true);
+
+      const fileContent = await fs.readFile(outputPath, 'utf-8');
+      const parsedContent = JSON.parse(fileContent);
+      expect(parsedContent.openapi).toBe('3.0.3');
+    });
+  });
+
+  describe('generateNestTspec', () => {
+    it('should generate OpenAPI spec from NestJS controllers', () => {
+      const spec = generateNestTspec({
+        tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
+        specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
+      });
+
+      expect(spec).toBeDefined();
+      expect(spec.openapi).toBe('3.0.3');
+      expect(spec.paths['/books']).toBeDefined();
+      expect(spec.paths['/books']?.get).toBeDefined();
+      expect(spec.paths['/books']?.post).toBeDefined();
+    });
+
+    it('should use custom openapi options for NestJS', () => {
+      const spec = generateNestTspec({
+        tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
+        specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
+        openapi: {
+          title: 'NestJS Books API',
+          version: '3.0.0',
+          description: 'Books API generated from NestJS',
+        },
+      });
+
+      expect(spec.info.title).toBe('NestJS Books API');
+      expect(spec.info.version).toBe('3.0.0');
+      expect(spec.info.description).toBe('Books API generated from NestJS');
+    });
+
+    it('should include securityDefinitions for NestJS', () => {
+      const spec = generateNestTspec({
+        tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
+        specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
+        openapi: {
+          title: 'Secure API',
+          version: '1.0.0',
+          securityDefinitions: {
+            apiKey: {
+              type: 'apiKey',
+              in: 'header',
+              name: 'X-API-Key',
+            },
+          },
+        },
+      });
+
+      expect(spec.components?.securitySchemes).toBeDefined();
+      expect(spec.components?.securitySchemes?.apiKey).toEqual({
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-API-Key',
+      });
+    });
+
+    it('should include servers for NestJS', () => {
+      const spec = generateNestTspec({
+        tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
+        specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
+        openapi: {
+          title: 'API',
+          version: '1.0.0',
+          servers: [
+            { url: 'https://api.books.com', description: 'Production' },
+          ],
+        },
+      });
+
+      expect(spec.servers).toBeDefined();
+      expect(spec.servers).toHaveLength(1);
+      expect(spec.servers?.[0].url).toBe('https://api.books.com');
+    });
+
+    it('should parse multiple controllers', () => {
+      const spec = generateNestTspec({
+        tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
+        specPathGlobs: [
+          path.join(FIXTURES_DIR, 'books.controller.ts'),
+          path.join(FIXTURES_DIR, 'users.controller.ts'),
+        ],
+      });
+
+      expect(spec.paths['/books']).toBeDefined();
+      expect(spec.paths['/users']).toBeDefined();
+    });
+
+    it('should handle file upload controllers', () => {
+      const spec = generateNestTspec({
+        tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
+        specPathGlobs: [path.join(FIXTURES_DIR, 'files.controller.ts')],
+      });
+
+      expect(spec.paths['/files/upload']).toBeDefined();
+      const uploadOp = spec.paths['/files/upload']?.post as any;
+      expect(uploadOp?.requestBody?.content?.['multipart/form-data']).toBeDefined();
+    });
+  });
+
+  describe('Tspec.GenerateParams type compatibility', () => {
+    it('should accept all GenerateParams fields', async () => {
+      const params: Tspec.GenerateParams = {
+        specPathGlobs: ['src/**/*.ts'],
+        tsconfigPath: './tsconfig.json',
+        configPath: './tspec.config.json',
+        outputPath: './openapi.json',
+        specVersion: 3,
+        openapi: {
+          title: 'Test API',
+          version: '1.0.0',
+          description: 'Test description',
+          securityDefinitions: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+            },
+          },
+          servers: [{ url: 'https://api.test.com' }],
+        },
+        debug: false,
+        ignoreErrors: true,
+        nestjs: false,
+      };
+
+      expect(params.specPathGlobs).toEqual(['src/**/*.ts']);
+      expect(params.nestjs).toBe(false);
+      expect(params.openapi?.securityDefinitions).toBeDefined();
+      expect(params.openapi?.servers).toBeDefined();
+    });
+
+    it('should accept nestjs mode in GenerateParams', () => {
+      const params: Tspec.GenerateParams = {
+        specPathGlobs: ['src/**/*.controller.ts'],
+        tsconfigPath: './tsconfig.json',
+        nestjs: true,
+        openapi: {
+          title: 'NestJS API',
+          version: '1.0.0',
+        },
+      };
+
+      expect(params.nestjs).toBe(true);
+      expect(params.specPathGlobs).toEqual(['src/**/*.controller.ts']);
+    });
+  });
+
+  describe('InitTspecServerOptions type compatibility', () => {
+    it('should extend GenerateParams with server options', () => {
+      const options: Tspec.InitTspecServerOptions = {
+        specPathGlobs: ['src/**/*.ts'],
+        tsconfigPath: './tsconfig.json',
+        openapi: {
+          title: 'Server API',
+          version: '1.0.0',
+        },
+        port: 8080,
+        proxyHost: 'https://api.example.com',
+        nestjs: false,
+      };
+
+      expect(options.port).toBe(8080);
+      expect(options.proxyHost).toBe('https://api.example.com');
+      expect(options.nestjs).toBe(false);
+    });
+  });
+});

--- a/packages/tspec/src/test/generator.test.ts
+++ b/packages/tspec/src/test/generator.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { generateTspec, defaultGenerateParams, createJsonFile } from '../generator';
+import type { Tspec } from '../types/tspec';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SCENARIOS_DIR = path.join(__dirname, 'scenarios');
+const OUTPUT_DIR = path.join(__dirname, 'output');
+
+describe('Generator Module', () => {
+  beforeAll(async () => {
+    await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(OUTPUT_DIR, { recursive: true, force: true });
+  });
+
+  describe('defaultGenerateParams', () => {
+    it('should have correct default values', () => {
+      expect(defaultGenerateParams.specPathGlobs).toEqual(['**/*.ts']);
+      expect(defaultGenerateParams.tsconfigPath).toBe('tsconfig.json');
+      expect(defaultGenerateParams.configPath).toBe('tspec.config.json');
+      expect(defaultGenerateParams.specVersion).toBe(3);
+      expect(defaultGenerateParams.debug).toBe(false);
+      expect(defaultGenerateParams.ignoreErrors).toBe(true);
+    });
+
+    it('should have correct default openapi values', () => {
+      expect(defaultGenerateParams.openapi.title).toBe('Tspec API');
+      expect(defaultGenerateParams.openapi.version).toBe('0.0.1');
+      expect(defaultGenerateParams.openapi.description).toBe('');
+    });
+  });
+
+  describe('generateTspec', () => {
+    it('should generate valid OpenAPI 3.0.3 document', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+      });
+
+      expect(spec.openapi).toBe('3.0.3');
+      expect(spec.info).toBeDefined();
+      expect(spec.paths).toBeDefined();
+      expect(typeof spec.paths).toBe('object');
+    });
+
+    it('should merge default params with provided params', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        openapi: {
+          title: 'Custom Title',
+        },
+      });
+
+      expect(spec.info.title).toBe('Custom Title');
+      // version should use default since not provided
+      expect(spec.info.version).toBe('0.0.1');
+    });
+
+    it('should generate components with schemas', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+      });
+
+      expect(spec.components).toBeDefined();
+      expect(spec.components?.schemas).toBeDefined();
+      expect(Object.keys(spec.components?.schemas || {}).length).toBeGreaterThan(0);
+    });
+
+    it('should include securitySchemes when securityDefinitions provided', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        openapi: {
+          securityDefinitions: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+              bearerFormat: 'JWT',
+            },
+            apiKey: {
+              type: 'apiKey',
+              in: 'header',
+              name: 'X-API-Key',
+            },
+          },
+        },
+      });
+
+      expect(spec.components?.securitySchemes).toBeDefined();
+      expect(spec.components?.securitySchemes?.bearerAuth).toBeDefined();
+      expect(spec.components?.securitySchemes?.apiKey).toBeDefined();
+    });
+
+    it('should include servers when provided', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        openapi: {
+          servers: [
+            { url: 'https://api.prod.com', description: 'Production' },
+            { url: 'https://api.staging.com', description: 'Staging' },
+            { url: 'http://localhost:3000', description: 'Development' },
+          ],
+        },
+      });
+
+      expect(spec.servers).toHaveLength(3);
+      expect(spec.servers?.[0]).toEqual({ url: 'https://api.prod.com', description: 'Production' });
+      expect(spec.servers?.[1]).toEqual({ url: 'https://api.staging.com', description: 'Staging' });
+      expect(spec.servers?.[2]).toEqual({ url: 'http://localhost:3000', description: 'Development' });
+    });
+
+    it('should generate paths from DefineApiSpec types', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+      });
+
+      expect(Object.keys(spec.paths).length).toBeGreaterThan(0);
+    });
+
+    it('should handle multiple spec files', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [
+          path.join(SCENARIOS_DIR, 'basic-types/spec.ts'),
+          path.join(SCENARIOS_DIR, 'nested-objects/spec.ts'),
+        ],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+      });
+
+      expect(spec.paths).toBeDefined();
+      expect(spec.components?.schemas).toBeDefined();
+    });
+  });
+
+  describe('createJsonFile', () => {
+    it('should create JSON file with formatted content', async () => {
+      const outputPath = path.join(OUTPUT_DIR, 'test-create.json');
+      const testData = { foo: 'bar', nested: { value: 123 } };
+
+      await createJsonFile(outputPath, testData);
+
+      const content = await fs.readFile(outputPath, 'utf-8');
+      const parsed = JSON.parse(content);
+      expect(parsed).toEqual(testData);
+    });
+
+    it('should create nested directories if they do not exist', async () => {
+      const outputPath = path.join(OUTPUT_DIR, 'nested/deep/test.json');
+      const testData = { test: true };
+
+      await createJsonFile(outputPath, testData);
+
+      const content = await fs.readFile(outputPath, 'utf-8');
+      const parsed = JSON.parse(content);
+      expect(parsed).toEqual(testData);
+    });
+
+    it('should format JSON with 2-space indentation', async () => {
+      const outputPath = path.join(OUTPUT_DIR, 'formatted.json');
+      const testData = { a: 1, b: 2 };
+
+      await createJsonFile(outputPath, testData);
+
+      const content = await fs.readFile(outputPath, 'utf-8');
+      expect(content).toContain('  "a": 1');
+      expect(content).toContain('  "b": 2');
+    });
+  });
+
+  describe('Output file generation', () => {
+    it('should write OpenAPI spec to file when outputPath provided', async () => {
+      const outputPath = path.join(OUTPUT_DIR, 'openapi-output.json');
+
+      await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        outputPath,
+      });
+
+      const fileExists = await fs.access(outputPath).then(() => true).catch(() => false);
+      expect(fileExists).toBe(true);
+
+      const content = await fs.readFile(outputPath, 'utf-8');
+      const spec = JSON.parse(content);
+      expect(spec.openapi).toBe('3.0.3');
+    });
+
+    it('should not write file when outputPath not provided', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+      });
+
+      // Should still return the spec
+      expect(spec).toBeDefined();
+      expect(spec.openapi).toBe('3.0.3');
+    });
+  });
+
+  describe('specVersion handling', () => {
+    it('should generate OpenAPI 3.0.3 for specVersion 3', async () => {
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+        specVersion: 3,
+      });
+
+      expect(spec.openapi).toBe('3.0.3');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle ignoreErrors option', async () => {
+      // With ignoreErrors: true, should not throw
+      const spec = await generateTspec({
+        specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
+        tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
+        ignoreErrors: true,
+      });
+
+      expect(spec).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add comprehensive tests for CLI and generator functions.

## Changes
- Add `cli.test.ts` with tests for `generateTspec` and `generateNestTspec`
- Add `generator.test.ts` with tests for `defaultGenerateParams` and output file generation
- Test `securityDefinitions`, `servers`, and `nestjs` options
- Test type compatibility for `GenerateParams` and `InitTspecServerOptions`

## Test Coverage
### cli.test.ts (14 tests)
- `generateTspec` function tests (5 tests)
- `generateNestTspec` function tests (6 tests)
- Type compatibility tests (3 tests)

### generator.test.ts (16 tests)
- `defaultGenerateParams` tests (2 tests)
- `generateTspec` function tests (7 tests)
- `createJsonFile` tests (3 tests)
- Output file generation tests (2 tests)
- `specVersion` handling tests (1 test)
- Error handling tests (1 test)

## Test Results
All 30 tests pass:
```
✓ src/test/generator.test.ts (16 tests)
✓ src/test/cli.test.ts (14 tests)

Test Files  2 passed (2)
Tests       30 passed (30)
```