### PR TITLE
feat: unify generateTspec with NestJS mode and extract common schema builder

### DIFF
--- a/packages/tspec/src/generator/schemaBuilder.ts
+++ b/packages/tspec/src/generator/schemaBuilder.ts
@@ -1,0 +1,277 @@
+import { OpenAPIV3 } from 'openapi-types';
+
+export interface TypeDefinition {
+  name: string;
+  properties: PropertyDefinition[];
+  description?: string;
+}
+
+export interface PropertyDefinition {
+  name: string;
+  type: string;
+  required: boolean;
+  description?: string;
+  isArray?: boolean;
+  enumValues?: string[];
+  example?: unknown;
+  format?: string;
+  deprecated?: boolean;
+  nullable?: boolean;
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  default?: unknown;
+}
+
+export interface EnumDefinition {
+  name: string;
+  values: string[];
+  description?: string;
+}
+
+export interface SchemaBuilderContext {
+  schemas: Record<string, OpenAPIV3.SchemaObject>;
+  typeDefinitions: Map<string, TypeDefinition>;
+  enumDefinitions: Map<string, EnumDefinition>;
+}
+
+export const buildPrimitiveSchema = (typeName: string): OpenAPIV3.SchemaObject => {
+  switch (typeName.toLowerCase()) {
+    case 'string':
+      return { type: 'string' };
+    case 'number':
+      return { type: 'number' };
+    case 'boolean':
+      return { type: 'boolean' };
+    case 'any':
+    case 'unknown':
+      return {};
+    default:
+      return {};
+  }
+};
+
+export const unwrapPromise = (type: string): string => {
+  const promiseMatch = type.match(/^Promise<(.+)>$/);
+  if (promiseMatch) {
+    return promiseMatch[1];
+  }
+  return type;
+};
+
+export const buildSchemaRef = (
+  typeName: string,
+  context: SchemaBuilderContext,
+): OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject => {
+  const { schemas, typeDefinitions, enumDefinitions } = context;
+
+  const primitiveSchema = buildPrimitiveSchema(typeName);
+  if (primitiveSchema.type) {
+    return primitiveSchema;
+  }
+
+  // Handle nullable types (T | null, T | undefined)
+  const nullableMatch = typeName.match(/^(.+?)\s*\|\s*(null|undefined)$/) ||
+                        typeName.match(/^(null|undefined)\s*\|\s*(.+)$/);
+  if (nullableMatch) {
+    const innerType = nullableMatch[1] === 'null' || nullableMatch[1] === 'undefined' 
+      ? nullableMatch[2] 
+      : nullableMatch[1];
+    const innerSchema = buildSchemaRef(innerType.trim(), context);
+    // OpenAPI 3.0 nullable
+    if ('$ref' in innerSchema) {
+      return { allOf: [innerSchema], nullable: true };
+    }
+    return { ...innerSchema, nullable: true };
+  }
+
+  // Handle inline object types like { status: string; message: string; }
+  if (typeName.startsWith('{') && typeName.endsWith('}')) {
+    return parseInlineObjectType(typeName, context);
+  }
+
+  // Handle array types
+  const arrayMatch = typeName.match(/^(.+)\[\]$/);
+  if (arrayMatch) {
+    return {
+      type: 'array',
+      items: buildSchemaRef(arrayMatch[1], context),
+    };
+  }
+
+  // Handle generic array types like Array<T>
+  const genericArrayMatch = typeName.match(/^Array<(.+)>$/);
+  if (genericArrayMatch) {
+    return {
+      type: 'array',
+      items: buildSchemaRef(genericArrayMatch[1], context),
+    };
+  }
+
+  // Handle generic types like DataResponse<T>, PaginatedResponse<T>
+  const genericMatch = typeName.match(/^(\w+)<(.+)>$/);
+  if (genericMatch) {
+    const [, wrapperType, innerType] = genericMatch;
+    
+    // Look up the wrapper type definition and substitute the type parameter
+    const wrapperDef = typeDefinitions.get(wrapperType);
+    if (wrapperDef && wrapperDef.properties.length > 0) {
+      const properties: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject> = {};
+      const required: string[] = [];
+
+      for (const prop of wrapperDef.properties) {
+        // Substitute type parameter T with the actual inner type
+        let propType = prop.type;
+        if (propType === 'T') {
+          propType = innerType;
+        } else if (propType === 'T[]') {
+          propType = `${innerType}[]`;
+        } else if (propType.includes('<T>')) {
+          propType = propType.replace('<T>', `<${innerType}>`);
+        }
+        
+        properties[prop.name] = buildSchemaRef(propType, context);
+        if (prop.required) {
+          required.push(prop.name);
+        }
+      }
+
+      return {
+        type: 'object',
+        properties,
+        required: required.length > 0 ? required : undefined,
+      };
+    }
+    
+    // Fallback: just resolve the inner type if wrapper definition not found
+    return buildSchemaRef(innerType, context);
+  }
+
+  // Handle Date type
+  if (typeName === 'Date') {
+    return { type: 'string', format: 'date-time' };
+  }
+
+  // Check if it's an enum
+  const enumDef = enumDefinitions.get(typeName);
+  if (enumDef) {
+    if (!schemas[typeName]) {
+      schemas[typeName] = {
+        type: 'string',
+        enum: enumDef.values,
+        description: enumDef.description,
+      };
+    }
+    return { $ref: `#/components/schemas/${typeName}` };
+  }
+
+  // Register as a reference schema with resolved properties
+  if (!schemas[typeName]) {
+    const typeDef = typeDefinitions.get(typeName);
+    if (typeDef && typeDef.properties.length > 0) {
+      const properties: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject> = {};
+      const required: string[] = [];
+
+      for (const prop of typeDef.properties) {
+        const baseSchema = buildSchemaRef(prop.type, context);
+        
+        // Merge JSDoc tags into the schema
+        const propSchema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject = '$ref' in baseSchema
+          ? baseSchema
+          : {
+              ...baseSchema,
+              description: prop.description || baseSchema.description,
+              example: prop.example,
+              format: prop.format || baseSchema.format,
+              deprecated: prop.deprecated,
+              minimum: prop.minimum,
+              maximum: prop.maximum,
+              minLength: prop.minLength,
+              maxLength: prop.maxLength,
+              pattern: prop.pattern,
+              default: prop.default,
+            };
+        
+        // Clean up undefined values
+        if (!('$ref' in propSchema)) {
+          Object.keys(propSchema).forEach((key) => {
+            if ((propSchema as Record<string, unknown>)[key] === undefined) {
+              delete (propSchema as Record<string, unknown>)[key];
+            }
+          });
+        }
+        
+        properties[prop.name] = propSchema;
+        if (prop.required) {
+          required.push(prop.name);
+        }
+      }
+
+      schemas[typeName] = {
+        type: 'object',
+        description: typeDef.description,
+        properties,
+        required: required.length > 0 ? required : undefined,
+      };
+    } else {
+      schemas[typeName] = {
+        type: 'object',
+        description: `Schema for ${typeName}`,
+      };
+    }
+  }
+
+  return { $ref: `#/components/schemas/${typeName}` };
+};
+
+// Parse inline object types like { status: string; message: string; }
+const parseInlineObjectType = (
+  typeName: string,
+  context: SchemaBuilderContext,
+): OpenAPIV3.SchemaObject => {
+  const inner = typeName.slice(1, -1).trim();
+  if (!inner) {
+    return { type: 'object' };
+  }
+
+  const properties: Record<string, OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject> = {};
+  const required: string[] = [];
+
+  // Parse properties like "status: string; message: string;"
+  const propMatches = inner.split(';').filter(p => p.trim());
+  for (const propStr of propMatches) {
+    const colonIndex = propStr.indexOf(':');
+    if (colonIndex === -1) continue;
+
+    let propName = propStr.slice(0, colonIndex).trim();
+    const propType = propStr.slice(colonIndex + 1).trim();
+
+    // Check for optional property (name?)
+    const isOptional = propName.endsWith('?');
+    if (isOptional) {
+      propName = propName.slice(0, -1);
+    }
+
+    properties[propName] = buildSchemaRef(propType, context);
+    if (!isOptional) {
+      required.push(propName);
+    }
+  }
+
+  return {
+    type: 'object',
+    properties,
+    required: required.length > 0 ? required : undefined,
+  };
+};
+
+export const createSchemaBuilderContext = (
+  typeDefinitions?: Map<string, TypeDefinition>,
+  enumDefinitions?: Map<string, EnumDefinition>,
+): SchemaBuilderContext => ({
+  schemas: {},
+  typeDefinitions: typeDefinitions || new Map(),
+  enumDefinitions: enumDefinitions || new Map(),
+});

--- a/packages/tspec/src/nestjs/index.ts
+++ b/packages/tspec/src/nestjs/index.ts
@@ -14,17 +14,25 @@ export type {
   ParsedNestApp,
   HttpMethod,
 } from './types';
+export type { GenerateOpenApiOptions } from './openapiGenerator';
+
+/**
+ * @deprecated Use `Tspec.GenerateParams` instead
+ */
+export type GenerateNestTspecOptions = Tspec.GenerateParams;
 
 /**
  * Generate OpenAPI spec from NestJS controllers programmatically
  * 
+ * @deprecated Use `generateTspec` with `nestjs: true` instead
  * @example
  * ```typescript
- * import { generateNestTspec } from 'tspec';
+ * import { generateTspec } from 'tspec';
  * 
- * const spec = generateNestTspec({
+ * const spec = await generateTspec({
  *   tsconfigPath: './tsconfig.json',
  *   specPathGlobs: ['src/**\/*.controller.ts'],
+ *   nestjs: true,
  *   openapi: {
  *     title: 'My API',
  *     version: '1.0.0',


### PR DESCRIPTION
## Summary
Unify `generateNestTspec` into `generateTspec` and extract common schema building logic into a shared module.

## Changes

### 1. New `generator/schemaBuilder.ts`
Extract common schema building logic that can be shared between standard Tspec mode and NestJS mode:
- `buildPrimitiveSchema()` - Build OpenAPI schema for primitive types
- `buildSchemaRef()` - Build schema reference with type resolution
- `unwrapPromise()` - Unwrap Promise types
- `createSchemaBuilderContext()` - Create context for schema building

### 2. Updated `nestjs/openapiGenerator.ts`
- Now imports and uses shared schema builder functions
- Removed duplicate schema building code (~230 lines removed)
- Cleaner, more maintainable code

### 3. Updated `generator/index.ts`
- `generateTspec` now supports `nestjs: true` option
- When `nestjs` is enabled, uses `specPathGlobs` for controller file patterns
- Unified API for both standard and NestJS modes

### 4. Updated `nestjs/index.ts`
- `generateNestTspec` is now deprecated
- `GenerateNestTspecOptions` type is now deprecated
- Both still work for backward compatibility

## Usage

### Before (deprecated)
```typescript
import { generateNestTspec } from 'tspec';

const spec = generateNestTspec({
  tsconfigPath: './tsconfig.json',
  controllerGlobs: ['src/**/*.controller.ts'],
  openapi: { title: 'My API' },
});
```

### After (recommended)
```typescript
import { generateTspec } from 'tspec';

const spec = await generateTspec({
  tsconfigPath: './tsconfig.json',
  specPathGlobs: ['src/**/*.controller.ts'],
  nestjs: true,
  openapi: { title: 'My API' },
});
```

## Breaking Changes
- `generateNestTspec` is deprecated (still works, but shows deprecation warning)
- `GenerateNestTspecOptions` type is deprecated (use `Tspec.GenerateParams` instead)

## Test Results
All 102 tests pass.