### PR TITLE
fix(nestjs): include DTO fields in multipart/form-data and auto-generate 200 response

### DIFF
--- a/packages/tspec/src/cli/index.ts
+++ b/packages/tspec/src/cli/index.ts
@@ -29,6 +29,8 @@ interface GeneratorOptions {
   ignoreErrors?: boolean,
   /** Enable NestJS controller parsing mode (uses specPathGlobs for controller files) */
   nestjs?: boolean,
+  /** Suppress all console output */
+  silent?: boolean,
 }
 
 interface RunServerOptions extends GeneratorOptions {
@@ -53,6 +55,7 @@ const generatorOptions = {
   ...baseOptions,
   outputPath: { type: 'string', default: 'openapi.json' },
   nestjs: { type: 'boolean', default: false, description: 'Generate from NestJS controllers (uses specPathGlobs for controller files)' },
+  silent: { type: 'boolean', default: false, description: 'Suppress all console output' },
 } as const;
 
 const runServerOptions = {
@@ -73,7 +76,7 @@ const validateGeneratorOptions = (args: GeneratorOptions): Tspec.GenerateParams 
       : undefined,
     tsconfigPath: args.tsconfigPath !== defaultArgs.tsconfigPath ? args.tsconfigPath : undefined,
     configPath: args.configPath !== defaultArgs.configPath ? args.configPath : undefined,
-    outputPath: args.outputPath,
+    outputPath: args.outputPath !== 'openapi.json' ? args.outputPath : undefined,
     specVersion: args.specVersion !== defaultArgs.specVersion ? args.specVersion : undefined,
     openapi: {
       title: args.openapiTitle !== defaultArgs.openapi.title ? args.openapiTitle : undefined,
@@ -93,6 +96,11 @@ const specGenerator = async (args: GeneratorOptions) => {
   // NestJS mode: add nestjs flag to params
   if (args.nestjs) {
     generateTspecParams.nestjs = true;
+  }
+
+  // Silent mode: suppress console output
+  if (args.silent) {
+    generateTspecParams.silent = true;
   }
 
   await generateTspec(generateTspecParams);

--- a/packages/tspec/src/test/cli.test.ts
+++ b/packages/tspec/src/test/cli.test.ts
@@ -27,6 +27,7 @@ describe('CLI and Generate Function', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
       });
 
       expect(spec).toBeDefined();
@@ -40,6 +41,7 @@ describe('CLI and Generate Function', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         openapi: {
           title: 'Custom API Title',
           version: '2.0.0',
@@ -57,6 +59,7 @@ describe('CLI and Generate Function', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         openapi: {
           title: 'API with Security',
           version: '1.0.0',
@@ -83,6 +86,7 @@ describe('CLI and Generate Function', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         openapi: {
           title: 'API with Servers',
           version: '1.0.0',
@@ -106,6 +110,7 @@ describe('CLI and Generate Function', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         outputPath,
       });
 
@@ -124,6 +129,7 @@ describe('CLI and Generate Function', () => {
         tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
         specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
         nestjs: true,
+        silent: true,
       });
 
       expect(spec).toBeDefined();
@@ -138,6 +144,7 @@ describe('CLI and Generate Function', () => {
         tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
         specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
         nestjs: true,
+        silent: true,
         openapi: {
           title: 'NestJS Books API',
           version: '3.0.0',
@@ -155,6 +162,7 @@ describe('CLI and Generate Function', () => {
         tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
         specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
         nestjs: true,
+        silent: true,
         openapi: {
           title: 'Secure API',
           version: '1.0.0',
@@ -181,6 +189,7 @@ describe('CLI and Generate Function', () => {
         tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
         specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
         nestjs: true,
+        silent: true,
         openapi: {
           title: 'API',
           version: '1.0.0',
@@ -203,6 +212,7 @@ describe('CLI and Generate Function', () => {
           path.join(FIXTURES_DIR, 'users.controller.ts'),
         ],
         nestjs: true,
+        silent: true,
       });
 
       expect(spec.paths['/books']).toBeDefined();
@@ -214,6 +224,7 @@ describe('CLI and Generate Function', () => {
         tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
         specPathGlobs: [path.join(FIXTURES_DIR, 'files.controller.ts')],
         nestjs: true,
+        silent: true,
       });
 
       expect(spec.paths['/files/upload']).toBeDefined();
@@ -226,6 +237,7 @@ describe('CLI and Generate Function', () => {
         tsconfigPath: path.join(FIXTURES_DIR, 'tsconfig.json'),
         specPathGlobs: [path.join(FIXTURES_DIR, 'books.controller.ts')],
         nestjs: true,
+        silent: true,
       });
 
       // findOne method has @ApiResponse decorators

--- a/packages/tspec/src/test/generator.test.ts
+++ b/packages/tspec/src/test/generator.test.ts
@@ -43,6 +43,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
       });
 
       expect(spec.openapi).toBe('3.0.3');
@@ -56,6 +57,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         openapi: {
           title: 'Custom Title',
         },
@@ -71,6 +73,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
       });
 
       expect(spec.components).toBeDefined();
@@ -83,6 +86,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         openapi: {
           securityDefinitions: {
             bearerAuth: {
@@ -109,6 +113,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         openapi: {
           servers: [
             { url: 'https://api.prod.com', description: 'Production' },
@@ -129,6 +134,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
       });
 
       expect(Object.keys(spec.paths).length).toBeGreaterThan(0);
@@ -142,6 +148,7 @@ describe('Generator Module', () => {
         ],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
       });
 
       expect(spec.paths).toBeDefined();
@@ -192,6 +199,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         outputPath,
       });
 
@@ -208,6 +216,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
       });
 
       // Should still return the spec
@@ -222,6 +231,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
         specVersion: 3,
       });
 
@@ -236,6 +246,7 @@ describe('Generator Module', () => {
         specPathGlobs: [path.join(SCENARIOS_DIR, 'basic-types/spec.ts')],
         tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
         ignoreErrors: true,
+        silent: true,
       });
 
       expect(spec).toBeDefined();

--- a/packages/tspec/src/test/nestjs/fixtures/files.controller.ts
+++ b/packages/tspec/src/test/nestjs/fixtures/files.controller.ts
@@ -50,6 +50,28 @@ interface FileMetadata {
 }
 
 /**
+ * DTO for file upload with additional fields
+ */
+class CreateFromImageDto {
+  /**
+   * 섭취 시간
+   * @format date-time
+   * @example "2024-11-24T12:30:00.000Z"
+   */
+  intakeAt?: string;
+
+  /**
+   * 메모
+   */
+  memo?: string;
+}
+
+// Mock ApiResponse decorator
+function ApiResponse(options: { status: number; description?: string; type?: any }): MethodDecorator {
+  return () => {};
+}
+
+/**
  * File Upload Controller
  */
 @Controller('files')
@@ -85,5 +107,31 @@ export class FilesController {
     @Body() metadata: FileMetadata,
   ): Promise<UploadResponse> {
     return Promise.resolve({ fileName: file.originalname, url: '' });
+  }
+
+  /**
+   * Upload image with DTO fields (Issue #87 test case 1)
+   * @summary Upload image with additional DTO fields
+   */
+  @Post('from-image')
+  @UseInterceptors(FileInterceptor('file'))
+  createFromImage(
+    @UploadedFile() file: MulterFile,
+    @Body() dto: CreateFromImageDto,
+  ): Promise<UploadResponse> {
+    return Promise.resolve({ fileName: file.originalname, url: '' });
+  }
+
+  /**
+   * Endpoint with only error ApiResponse (Issue #87 test case 2)
+   * @summary Test endpoint with only error response defined
+   */
+  @Post('with-error-response')
+  @ApiResponse({ status: 409, description: 'Conflict error' })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  createWithErrorResponse(
+    @Body() metadata: FileMetadata,
+  ): Promise<UploadResponse> {
+    return Promise.resolve({ fileName: '', url: '' });
   }
 }

--- a/packages/tspec/src/test/schema-generation.test.ts
+++ b/packages/tspec/src/test/schema-generation.test.ts
@@ -39,6 +39,7 @@ async function generateSpec(scenarioDir: string): Promise<OpenAPIV3.Document> {
     specPathGlobs: [specPath],
     tsconfigPath: path.join(__dirname, '../../tsconfig.json'),
     ignoreErrors: true,
+    silent: true,
   });
 }
 
@@ -54,7 +55,7 @@ describe('Tspec Schema Generation', () => {
 
     beforeAll(async () => {
       spec = await generateSpec(path.join(SCENARIOS_DIR, 'basic-types'));
-    });
+    }, 30000);
 
     it('should generate User schema with correct properties', () => {
       const userSchema = getComponentSchema(spec, 'User');

--- a/packages/tspec/src/types/tspec.ts
+++ b/packages/tspec/src/types/tspec.ts
@@ -123,6 +123,8 @@ export namespace Tspec {
     ignoreErrors?: boolean,
     /** Enable NestJS controller parsing mode (uses specPathGlobs for controller files) */
     nestjs?: boolean,
+    /** Suppress all console output */
+    silent?: boolean,
   }
 
   export interface InitTspecServerOptions extends GenerateParams {


### PR DESCRIPTION
Fixes #87

## Problem

Two issues when using tspec with NestJS controllers:

### Issue 1: Multipart form-data DTO fields not included in schema

When using `@ApiConsumes("multipart/form-data")` with `@UseInterceptors(FileInterceptor("file"))` and `@Body() dto`, only the `file` field was included in the generated schema. Other DTO fields were missing.

**Root cause**: `buildSchemaRef` returns a `$ref` for complex types, which doesn't have `properties` directly. The code was checking for `properties` on the `$ref` object instead of resolving it.

### Issue 2: Missing 200 response when only error responses defined

When a controller method only has `@ApiResponse` decorators for error cases (e.g., 409, 400), the 200 success response was not generated.

**Root cause**: The code only generated success responses when no `@ApiResponse` decorators were present.

## Solution

### Issue 1 Fix
When processing body params for multipart/form-data, resolve `$ref` from `context.schemas` to get the actual properties.

### Issue 2 Fix
Check if any success response (2xx) is defined via `@ApiResponse`. If not, auto-generate one from the return type.

## Additional Improvements

- **Fixed CLI outputPath**: CLI's default `outputPath` was always overriding config file settings. Now it only passes `outputPath` if different from CLI default.
- **Added verbose logging**: Generation now shows progress (controllers found, methods, paths, schemas generated)
- **Added `--silent` option**: New CLI flag and config option to suppress all console output

## Example Output

```
$ npx tspec generate --nestjs
Parsing NestJS controllers...
Found 3 controller(s)
  - BooksController: 5 method(s)
  - UsersController: 4 method(s)
  - FilesController: 3 method(s)
Generating OpenAPI spec...
Generated: ./openapi.json
```

## Changes

- `src/nestjs/openapiGenerator.ts`: Resolve `$ref` for multipart body params, auto-generate 200 response
- `src/cli/index.ts`: Fix outputPath override, add `--silent` option
- `src/generator/index.ts`: Add verbose logging with silent mode support
- `src/types/tspec.ts`: Add `silent` option to GenerateParams
- Added test cases for both issues